### PR TITLE
Add test for dashboard link

### DIFF
--- a/spec/features/guest_views_shop_spec.rb
+++ b/spec/features/guest_views_shop_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe "a guest", type: :feature do
   fixtures :photos
 
   it "can visit a store from the correct url" do
-    alon = User.find_by(name: "Alon Example")
+    alon = User.find_by(email: "alon@example.ninja")
     store = Store.create(name: "alonstore", tagline: "my store", user_id: alon.id)
-    photo = Photo.update(Photo.first.id, title: "AlonPhoto", description: "yeah", standard_price: 100, store_id: store.id)
+    Photo.update(Photo.first.id, title: "AlonPhoto", description: "yeah", standard_price: 100, store_id: store.id)
 
     visit store_photos_path(store.slug) 
 

--- a/spec/features/logged_in_user_spec.rb
+++ b/spec/features/logged_in_user_spec.rb
@@ -1,8 +1,11 @@
 require "rails_helper"
 
-RSpec.describe "the profile view", type: :feature do
+RSpec.describe "profile view", type: :feature do
   fixtures :users
-  let!(:user) {User.first}
+  fixtures :stores
+
+  let!(:user) { User.find_by(email: "jason@example.ninja") }
+  let!(:store_admin) { User.find_by(email: "admin@admin.com") }
 
   context "a logged in user" do
     before do
@@ -13,22 +16,34 @@ RSpec.describe "the profile view", type: :feature do
       expect(page).to have_content "YeeHaw! #{user.name} is signed in!"
       expect(page).to have_link "Profile"
 
-      within(".navbar-nav") do
-        click_link "Profile"
-      end
-
       expect(current_path).to eq profile_path
       expect(page).to have_content "#{user.name}'s Profile"
     end
+
+    it "does not have a dashboard link" do
+      expect(page).to_not have_link("Dashboard")
+    end
   end
 
-  context "user who's not logged in" do
+
+  context "a user who's not logged in" do
     it "can't visit the profile page" do
       visit root_path
       expect(page).to_not have_link "Profile"
+      expect(page).to_not have_link "Dashboard"
 
       visit profile_path
       expect(current_path).to eq "/404"
+    end
+  end
+
+  context "a logged in store administrator" do
+    before do
+      sign_in(store_admin)
+    end
+
+    it "has a dashboard link" do
+      expect(page).to have_link("Dashboard")
     end
   end
 

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -7,17 +7,18 @@ user_<%= n + 1 %>:
 <% end %>
 
 alon:
-  name: Alon Example
+  name: Alon
   email: alon@example.ninja
   password_digest: <%= User.digest("password") %>
 
 jason:
-  name: Jason Example
+  id: 102
+  name: Jason
   email: jason@example.ninja
   password_digest: <%= User.digest("password") %>
 
 ryan:
-  name: Ryan Example
+  name: Ryan
   email: ryan@example.ninja
   password_digest: <%= User.digest("password") %>
 


### PR DESCRIPTION
closes #108 
- test for store admin showing dashboard link in header
- updated user fixture
- updated failing test caused by fixture changes
