### PR TITLE
File location to all cloudinary

### DIFF
--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -7,7 +7,7 @@ class OrderItem < ActiveRecord::Base
   end
 
   def image_url(type = :preview)
-    photo.file_location(type)
+    photo.file_url(type)
   end
 
   def description

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -12,10 +12,6 @@ class Photo < ActiveRecord::Base
     description.length > 60 ? (description[0..60] + "...") : description
   end
 
-  # def file_location(type = :preview)
-  #   file_url ? file_url : seed_url(type)
-  # end
-
   def self.active
     where(active: true)
   end
@@ -28,14 +24,4 @@ class Photo < ActiveRecord::Base
     end
   end
 
-  # private
-  #
-  #   def seed_url(type)
-  #     type = type.to_s
-  #     file_url ? file_url : seed_path + "#{type}/" + seed_name + "_#{type}.jpg"
-  #   end
-  #
-  #   def seed_path
-  #     "http://mowalon.com/images/photos_ready/"
-  #   end
 end

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -12,9 +12,9 @@ class Photo < ActiveRecord::Base
     description.length > 60 ? (description[0..60] + "...") : description
   end
 
-  def file_location(type = :preview)
-    file_url ? file_url : seed_url(type)
-  end
+  # def file_location(type = :preview)
+  #   file_url ? file_url : seed_url(type)
+  # end
 
   def self.active
     where(active: true)
@@ -28,14 +28,14 @@ class Photo < ActiveRecord::Base
     end
   end
 
-  private
-
-    def seed_url(type)
-      type = type.to_s
-      file_url ? file_url : seed_path + "#{type}/" + seed_name + "_#{type}.jpg"
-    end
-
-    def seed_path
-      "http://mowalon.com/images/photos_ready/"
-    end
+  # private
+  #
+  #   def seed_url(type)
+  #     type = type.to_s
+  #     file_url ? file_url : seed_path + "#{type}/" + seed_name + "_#{type}.jpg"
+  #   end
+  #
+  #   def seed_path
+  #     "http://mowalon.com/images/photos_ready/"
+  #   end
 end

--- a/app/uploaders/photo_uploader.rb
+++ b/app/uploaders/photo_uploader.rb
@@ -48,6 +48,9 @@ class PhotoUploader < CarrierWave::Uploader::Base
     process :resize_to_fit => [5000, 350]
   end
 
+  version :full do
+  end
+
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
   # def extension_white_list

--- a/app/views/cart_items/index.html.erb
+++ b/app/views/cart_items/index.html.erb
@@ -31,7 +31,7 @@
       </tr>
       <tr>
         <% @cart_items.each do |cart_item| %>
-          <td><%= image_tag(cart_item.file_location(:thumbnail), height: 80, width: 80, class: "img-circle") %></td>
+          <td><%= image_tag(cart_item.file_url(:thumbnail), height: 80, width: 80, class: "img-circle") %></td>
           <td><%= cart_item.title %></td>
           <td><%= cart_item.description %></td>
           <td><%= dollars(cart_item.standard_price) %></td>

--- a/app/views/layouts/_admin_photo.html.erb
+++ b/app/views/layouts/_admin_photo.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <td><%= link_to image_tag(admin_photo.file_location(:thumbnail), alt: "A picture", class: "admin_image"), store_photo_path(admin_photo.store.slug,admin_photo) %>
+  <td><%= link_to image_tag(admin_photo.file_url(:thumbnail), alt: "A picture", class: "admin_image"), store_photo_path(admin_photo.store.slug,admin_photo) %>
   <td><%= link_to admin_photo.title, store_photo_path(admin_photo.store.slug, admin_photo) %></td>
   <td><% admin_photo.categories.each do |cat| %>
       <%= cat.name %>

--- a/app/views/layouts/_photo.html.erb
+++ b/app/views/layouts/_photo.html.erb
@@ -1,6 +1,6 @@
 <div class="col-sm-4 col-lg-4 col-md-4 item-box">
   <div class="thumbnail">
-    <%= link_to image_tag(photo.file_location(:preview), alt: "A picture", class: "item-image"), store_photo_path(photo.store, photo) %>
+    <%= link_to image_tag(photo.file_url(:preview), alt: "A picture", class: "item-image"), store_photo_path(photo.store, photo) %>
     <div class="caption">
       <h4 class="pull-right"><%= dollars(photo.standard_price) %></h4>
       <h4><%= link_to photo.title, store_photo_path(photo.store, photo) %></h4>

--- a/app/views/layouts/_store.html.erb
+++ b/app/views/layouts/_store.html.erb
@@ -4,7 +4,7 @@
       <h4><%= link_to store.name, store_photos_path(store.slug) %></h4>
         <% store.photos.sample(4).each do |photo| %>
           <div class="store-collage">
-            <%= link_to image_tag(photo.file_location(:thumbnail)), store_photos_path(store.slug) %>
+            <%= link_to image_tag(photo.file_url(:thumbnail)), store_photos_path(store.slug) %>
           </div>
         <% end %>
       <p><strong><%= store.tagline %></strong></p>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -35,7 +35,7 @@
             <%= order_item.photo.shortened_description %>
           </td>
           <td>
-            <%= link_to order_item.photo.file_location(:full), class: "btn btn-success btn-xs" do %>
+            <%= link_to order_item.photo.file_url, class: "btn btn-success btn-xs" do %>
               <i class="glyphicon glyphicon-cloud-download"></i>
             <% end %>
           </td>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -35,7 +35,7 @@
             <%= order_item.photo.shortened_description %>
           </td>
           <td>
-            <%= link_to order_item.photo.file_url, class: "btn btn-success btn-xs" do %>
+            <%= link_to order_item.photo.file_url(:full), class: "btn btn-success btn-xs" do %>
               <i class="glyphicon glyphicon-cloud-download"></i>
             <% end %>
           </td>

--- a/app/views/photos/show.html.erb
+++ b/app/views/photos/show.html.erb
@@ -14,7 +14,7 @@
     <div class="col-md-9">
 
       <div class="">
-        <%= image_tag @photo.file_location(:preview), class: "img-responsive" %>
+        <%= image_tag @photo.file_url(:preview), class: "img-responsive" %>
       </div>
     </div>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -82,9 +82,9 @@
           <% @photos.each do |photo| %>
       <div class="col-xs-2 col-sm-2 col-md-2 col-lg-2 item-box download-center">
         <div class="thumbnail download-center">
-            <%= link_to image_tag(photo.file_location(:thumbnail), size: "80"), store_photo_path(photo.store.slug, photo, style: "max-width: auto") %>
+            <%= link_to image_tag(photo.file_url(:thumbnail), size: "80"), store_photo_path(photo.store.slug, photo, style: "max-width: auto") %>
             <div class="caption download-center text-center">
-              <%= link_to photo.file_location(:full), class: "btn btn-success btn-xs" do %>
+              <%= link_to photo.file_url(:full), class: "btn btn-success btn-xs" do %>
                 <i class="glyphicon glyphicon-cloud-download"></i>
               <% end %>
             </div>

--- a/db/migrate/20151020035013_remove_seed_name_from_photos.rb
+++ b/db/migrate/20151020035013_remove_seed_name_from_photos.rb
@@ -1,0 +1,5 @@
+class RemoveSeedNameFromPhotos < ActiveRecord::Migration
+  def change
+    remove_column :photos, :seed_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151019043519) do
+ActiveRecord::Schema.define(version: 20151020035013) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,22 +50,11 @@ ActiveRecord::Schema.define(version: 20151019043519) do
   add_index "photo_categories", ["category_id"], name: "index_photo_categories_on_category_id", using: :btree
   add_index "photo_categories", ["photo_id"], name: "index_photo_categories_on_photo_id", using: :btree
 
-  create_table "photo_cateogries", force: :cascade do |t|
-    t.integer  "photo_id"
-    t.integer  "category_id"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
-  end
-
-  add_index "photo_cateogries", ["category_id"], name: "index_photo_cateogries_on_category_id", using: :btree
-  add_index "photo_cateogries", ["photo_id"], name: "index_photo_cateogries_on_photo_id", using: :btree
-
   create_table "photos", force: :cascade do |t|
     t.string   "title"
     t.string   "description"
     t.integer  "standard_price"
     t.integer  "commercial_price"
-    t.string   "seed_name"
     t.datetime "created_at",                      null: false
     t.datetime "updated_at",                      null: false
     t.integer  "store_id"
@@ -112,8 +101,6 @@ ActiveRecord::Schema.define(version: 20151019043519) do
   add_foreign_key "order_items", "photos"
   add_foreign_key "photo_categories", "categories"
   add_foreign_key "photo_categories", "photos"
-  add_foreign_key "photo_cateogries", "categories"
-  add_foreign_key "photo_cateogries", "photos"
   add_foreign_key "photos", "stores"
   add_foreign_key "store_admins", "stores"
   add_foreign_key "store_admins", "users"

--- a/spec/fixtures/photos.yml
+++ b/spec/fixtures/photos.yml
@@ -5,7 +5,7 @@ photo_<%= n + 1 %>:
   description: <%= "Example Description #{n + 1}" %>
   standard_price: <%= n*100 + 99 %>
   commercial_price: <%= n*100 + 10099 %>
-  seed_name: <%= n + 1 %>
+  file: <%= n + 1 %>
   store_id: <%= rand(20) + 1 %>
 <% end %>
 
@@ -16,7 +16,7 @@ admin_store_photo_1:
   standard_price: 2300
   commercial_price: 3500
   store_id: 101
-  seed_name: "101"
+  file: "101"
   file: 'fake_carrierwave_object'
 
 admin_store_photo_2:
@@ -26,7 +26,7 @@ admin_store_photo_2:
   standard_price: 8734
   commercial_price: 35034
   store_id: 101
-  seed_name: "102"
+  file: "102"
   file: 'fake_carrierwave_object'
 
 other_store_photo_3:
@@ -36,5 +36,5 @@ other_store_photo_3:
   standard_price: 8341
   commercial_price: 9087
   store_id: 102
-  seed_name: "103"
+  file: "103"
   file: 'fake_carrierwave_object'


### PR DESCRIPTION
Removed file_location from the Photo model since that was only intended to deal with the temporary scenario of using both a demo server and Cloudinary. Now that we're all-in with Cloudinary, we don't need it. Changed all references to file_location() to use file_url() instead and modified fixtures to load the file column instead of seed_name which was a temporary column used for the demo server. That column was also removed now that it's obsolete.
