### PR TITLE
Merge category and shop_category partials

### DIFF
--- a/app/views/layouts/_category.html.erb
+++ b/app/views/layouts/_category.html.erb
@@ -1,1 +1,1 @@
-<li><%= link_to category.name, photos_path(filter: category.id), class: "side-nav-element"%></li>
+<li><%= link_to category.name, send(path, filter: category.id), class: "side-nav-element"%></li>

--- a/app/views/layouts/_new_shop.html.erb
+++ b/app/views/layouts/_new_shop.html.erb
@@ -1,0 +1,4 @@
+<div class = "well" >
+  <h4> Want your own shop? </h4>
+  <%= link_to "Sign Up!", "/login", class: "list-group-item text-center" %>
+</div>

--- a/app/views/layouts/_shop_category.html.erb
+++ b/app/views/layouts/_shop_category.html.erb
@@ -1,1 +1,0 @@
-<li><%= link_to shop_category.name, store_photos_path(filter: shop_category.id), class: "side-nav-element"%></li>

--- a/app/views/layouts/_shop_sidebar.html.erb
+++ b/app/views/layouts/_shop_sidebar.html.erb
@@ -2,11 +2,8 @@
   <div class="well">
     <ul>
       <li><%= link_to "All Photos", store_photos_path(@store.slug, filter: 0), class: "side-nav-element"%></li>
-        <%= render partial: "layouts/shop_category", collection: @categories %>
+      <%= render partial: "layouts/category", collection: @categories, locals: {path: :store_photos_path} %>
     </ul>
   </div>
-    <div class = "well" >
-      <h4> Want your own shop? </h4>
-      <%= link_to "Sign Up!", "/login", class: "list-group-item text-center" %>
-    </div>
+  <%= render "layouts/new_shop" %>
 </div>

--- a/app/views/layouts/_sidebar.html.erb
+++ b/app/views/layouts/_sidebar.html.erb
@@ -2,11 +2,8 @@
   <div class="well">
     <ul>
       <li><%= link_to "All Photos", photos_path(filter: 0), class: "side-nav-element"%></li>
-        <%= render partial: "layouts/category", collection: @categories %>
+      <%= render partial: "layouts/category", collection: @categories, locals: {path: :photos_path} %>
     </ul>
   </div>
-    <div class = "well" >
-      <h4> Want your own shop? </h4>
-      <%= link_to "Sign Up!", "/login", class: "list-group-item text-center" %>
-    </div>
+  <%= render "layouts/new_shop" %>
 </div>


### PR DESCRIPTION
Changed the calls to category and shop_category partials from sidebar and shop_sidebar partials to send in the needed path as a local variable. Using send method within category partial since the path is actually a helper method that takes a 'filter' parameter to filter images on the related pages.
